### PR TITLE
Casting result_set.total_content_blocks and part_number as int

### DIFF
--- a/taxii_services/models.py
+++ b/taxii_services/models.py
@@ -1696,10 +1696,10 @@ class ResultSetPart(models.Model):
         if self.result_set.subscription:
             poll_response.subscription_id = self.result_set.subscription.subscription_id
 
-        poll_response.record_count = tm11.RecordCount(self.result_set.total_content_blocks, False)
+        poll_response.record_count = tm11.RecordCount(int(self.result_set.total_content_blocks), False)
         poll_response.more = self.more
         poll_response.result_id = str(self.result_set.pk)
-        poll_response.result_part_number = self.part_number
+        poll_response.result_part_number = int(self.part_number)
 
         for content_block in self.content_blocks.all():
             cb = content_block.to_content_block_11()


### PR DESCRIPTION
I was having errors with PollFulfillmentRequest errors caused by these values having the type "long", when input validation in libtaxii 1.1.105 requires them to be integers. As the value can never be a decimal, casting here is fine.

This patch fixes that issue and the PollFulfillmentHandler now functions as expected.

Raising it as a pull request in case anyone else has hit this issue.

Tested on Django 1.10.6
